### PR TITLE
be slightly more careful about the number of dimensions

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -919,6 +919,20 @@ private:
     ::pybind11::detail::npy_format_descriptor<Type>::register_dtype \
         ({PYBIND11_MAP2_LIST (PYBIND11_FIELD_DESCRIPTOR_EX, Type, __VA_ARGS__)})
 
+#define PYBIND11_NUMPY_OBJECT_DTYPE(Type) \
+    namespace pybind11 { namespace detail { \
+        template <> struct npy_format_descriptor<Type> { \
+        public: \
+            enum { value = npy_api::NPY_OBJECT_ }; \
+            static pybind11::dtype dtype() { \
+                if (auto ptr = npy_api::get().PyArray_DescrFromType_(value)) \
+                    return reinterpret_borrow<pybind11::dtype>(ptr); \
+                pybind11_fail("Unsupported buffer format!"); \
+            } \
+            static PYBIND11_DESCR name() { return _("object"); } \
+        }; \
+    }}
+
 template  <class T>
 using array_iterator = typename std::add_pointer<T>::type;
 


### PR DESCRIPTION
I'm not sure it's safe to assume that `buf.shape(1)` exists when `buf.ndim == 1`. Also, we should fail when the number of dimensions is greater than 2, since that isn't actually handled correctly. 